### PR TITLE
docs(readme): add how to start the server

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,6 +32,8 @@ class.
 Example
 -------
 
+Create an app.py
+
 ::
 
     from flask import Flask, render_template
@@ -46,3 +48,9 @@ Example
         while True:
             data = ws.receive()
             ws.send(data)
+
+Now you can start the server by
+
+::
+
+    flask run


### PR DESCRIPTION
Just add how to start the server to be more user friendly. 😃

I originally start the server by

```shell
python app.py
```

it immediately quit, and I thought it is broken.

Took me a while to find the solution at https://github.com/pallets/flask#a-simple-example

```shell
flask run
```