### PR TITLE
Add WebSocketRequestCompleted exception for normal WebSocket closures

### DIFF
--- a/src/flask_sock/__init__.py
+++ b/src/flask_sock/__init__.py
@@ -3,6 +3,18 @@ from flask import Blueprint, request, Response, current_app
 from simple_websocket import Server, ConnectionClosed
 
 
+class WebSocketRequestCompleted(Exception):
+    """Exception indicating that a WebSocket request has completed normally.
+
+    This exception can be used in Flask Sock applications to signify that a
+    WebSocket request has finished as expected, and should not be treated as an error.
+
+    It can be combined with the 'ignore_errors' option in Sentry's initialization
+    to ensure that such exceptions are not reported as errors in Sentry.
+    """
+    pass
+
+
 class Sock:
     """Instantiate the Flask-Sock extension.
 
@@ -81,7 +93,7 @@ class Sock:
                                 WSGI_LOCAL.already_handled = True
                             return ALREADY_HANDLED
                         elif ws.mode == 'gunicorn':
-                            raise StopIteration()
+                            raise WebSocketRequestCompleted()
                         elif ws.mode == 'werkzeug':
                             return super().__call__(*args, **kwargs)
                         else:


### PR DESCRIPTION
In relation to issue #64, under the configuration of running Flask with Gunicorn and Gevent, a StopIteration exception is not captured by Flask, but it enters the finally clause. Consequently, this exception is not caught higher up by Gunicorn's StopIteration handler. Referencing this section of Flask's codebase: [Flask on GitHub](https://github.com/pallets/flask/blob/main/src/flask/app.py#L1466C16-L1466C16). When error capturing tools like Sentry are used, this leads to the reporting of the exception. Is it possible to define this exception specifically, so that Sentry can easily ignore it, and to distinguish it from a normal StopIteration?